### PR TITLE
Add line numbers

### DIFF
--- a/src/fudge/log.clj
+++ b/src/fudge/log.clj
@@ -20,6 +20,15 @@
   [c k & args]
   (apply (k c) c args))
 
+(defmacro calling-meta
+  "Used by other macros to get the namespace, file and line of the log call.
+   Builds a def with a generated symbol to expand and evaluate for the info."
+  []
+  `(let [meta# (meta (def sym#))]
+    (-> meta#
+        (select-keys [:ns :file :line])
+        (update :ns str))))
+
 ;; # Log-levels
 
 (defn set-valid-levels
@@ -52,12 +61,15 @@
       {:message data}))
 
 (defn prepare-data-for-logging
-  "Prepare the `data` structure being logged by setting the `:level`
-   and `:date` values"
-  [config data level]
+  "Prepare the `data` structure being logged by setting the `:level`,
+   `:date`, `:ns`, `:file` and `:line` values"
+  [config data level calling-meta]
   (->> data
        normalize-data
        (merge {:date (call config :date-fn)
+               :ns (:ns calling-meta)
+               :file (:file calling-meta)
+               :line (:line calling-meta)
                :level level})))
 
 ;; # The logger configuration
@@ -118,40 +130,45 @@
 
 ;; # Main logging functions
 
-(defn log
-  "Log a record with the config, level, and data provided"
-  [c level data]
-  (let [record (invoke c :prepare-fn data level)]
+(defn log!
+  "Log a record with the config, level, form metadata and data provided"
+  [c calling-meta level data]
+  (let [record (invoke c :prepare-fn data level calling-meta)]
     (when (invoke c :log?-fn record)
       (->> record
            (call c :format-fn)
            (call c :output-fn)))))
 
-(defn spy-with
+(defmacro log
+  "Log a record with the config, level, and data provided"
+  [c level data]
+  `(log! ~c (calling-meta) ~level ~data))
+
+(defmacro spy-with
   "Log a record about a data value, first applying the transform
    supplied.  Returns the original, untransformed value.  Designed
    to be used in threaded pipelines.  For example:
 
-      (-> {:counter 1}
-          (update :counter inc)
-          (spy-with #(str \"The number is now \" (:counter %)))
-          (update :counter inc))"
+      (->> {:counter 1}
+           (update :counter inc)
+           (spy-with #(str \"The number is now \" (:counter %)))
+           (update :counter inc))"
   [c transform level data]
-  (doto data
-    (->> transform
-         (log c level))))
+  `(doto ~data
+    (->> (~transform)
+         (log ~c ~level))))
 
-(defn spy
+(defmacro spy
   "Log a record about a data value as per `spy-with`, but with no transformation."
   [c level data]
-  (spy-with c identity level data))
+  `(spy-with ~c identity ~level ~data))
 
 ;; # Common format configs
 
 (defn format-plain
   "Simple plain string formatter"
-  [{:keys [:date :level :message]}]
-  (str date " [" level "] " message))
+  [{:keys [:ns :line :date :level :message]}]
+  (str date " [" ns ":" line "] [" (name level) "] " message))
 
 (def plain-config
   "Config for a plain text log message format"

--- a/test/fudge/log_test.clj
+++ b/test/fudge/log_test.clj
@@ -57,10 +57,10 @@
                   :format-fn (juxt :level :message)
                   :output-fn (partial clojure.string/join " ")}]
       (is (= ":info MSG" (log logger :info {:message "MSG"})))))
-  (testing "Don't log")
+  (testing "Don't log"
     (let [logger {:prepare-fn (constantly {})
                   :log?-fn (constantly false)}]
-      (is (= nil (log logger :info {:message "MSG"})))))
+      (is (= nil (log logger :info {:message "MSG"}))))))
 
 (deftest test-spy-and-spy-with
   (let [out (atom "")

--- a/test/fudge/log_test.clj
+++ b/test/fudge/log_test.clj
@@ -83,14 +83,22 @@
                 :log?-fn (constantly true)
                 :format-fn identity
                 :output-fn (partial reset! out)}]
-    (testing "spy-with"
-      (let [result (spy-with logger count :info "Hello")]
-        (is (= "Hello" result))
-        (is (= 5 @out))))
-    (testing "spy"
-      (let [result (spy logger :info "Hello")]
-        (is (= "Hello" result))
-        (is (= "Hello" @out))))))
+    (testing "spy-with->>"
+      (let [result (spy-with->> logger count :info "Thread last")]
+        (is (= "Thread last" result))
+        (is (= 11 @out))))
+    (testing "spy-with->"
+      (let [result (spy-with-> "Thread first" logger count :info)]
+        (is (= "Thread first" result))
+        (is (= 12 @out))))
+    (testing "spy->>"
+      (let [result (spy->> logger :info "Thread last")]
+        (is (= "Thread last" result))
+        (is (= "Thread last" @out))))
+    (testing "spy->"
+      (let [result (spy-> "Thread first" logger :info)]
+        (is (= "Thread first" result))
+        (is (= "Thread first" @out))))))
 
 (deftest test-formats
   (let [record {:date "2017-07-08"
@@ -126,33 +134,33 @@
       (let [logger (plain-logger)
             result (with-out-str
                      (log logger :info "foo"))]
-        (is (= "2017-05-12T18:01 [fudge.log-test:128] [info] foo\n" result))))
+        (is (= "2017-05-12T18:01 [fudge.log-test:136] [info] foo\n" result))))
 
   (testing "multiple lines output"
     (let [logger (plain-logger)
           result (with-out-str
                     (log logger :info "foo")
                     (log logger :error "bar"))]
-      (is (= "2017-05-12T18:01 [fudge.log-test:134] [info] foo\n2017-05-12T18:02 [fudge.log-test:135] [error] bar\n" result))))
+      (is (= "2017-05-12T18:01 [fudge.log-test:142] [info] foo\n2017-05-12T18:02 [fudge.log-test:143] [error] bar\n" result))))
 
   (testing "pipeline"
     (let [logger (plain-logger)
           result (with-out-str
                    (->> 1
                         inc
-                        (spy logger :info)
+                        (spy->> logger :info)
                         inc
-                        (spy-with logger #(* 10 %) :info)))]
-      (is (= "2017-05-12T18:01 [fudge.log-test:143] [info] 2\n2017-05-12T18:02 [fudge.log-test:145] [info] 30\n" result)))))
+                        (spy-with->> logger #(* 10 %) :info)))]
+      (is (= "2017-05-12T18:01 [fudge.log-test:151] [info] 2\n2017-05-12T18:02 [fudge.log-test:153] [info] 30\n" result)))))
 
 (deftest test-json-logger
   (let [logger (json-logger)
         result (with-out-str
                  (log logger :info "foo"))]
-    (is (= "{\"date\":\"2017-05-12T18:01\",\"ns\":\"fudge.log-test\",\"file\":\"fudge/log_test.clj\",\"line\":151,\"level\":\"info\",\"message\":\"foo\"}\n" result))))
+    (is (= "{\"date\":\"2017-05-12T18:01\",\"ns\":\"fudge.log-test\",\"file\":\"fudge/log_test.clj\",\"line\":159,\"level\":\"info\",\"message\":\"foo\"}\n" result))))
 
 (deftest test-aws-logger
   (let [logger (aws-logger)
         result (with-out-str
                  (log logger :info "foo"))]
-    (is (= "2017-05-12T18:01 {\"ns\":\"fudge.log-test\",\"file\":\"fudge/log_test.clj\",\"line\":157,\"level\":\"info\",\"message\":\"foo\"}\n" result))))
+    (is (= "2017-05-12T18:01 {\"ns\":\"fudge.log-test\",\"file\":\"fudge/log_test.clj\",\"line\":165,\"level\":\"info\",\"message\":\"foo\"}\n" result))))


### PR DESCRIPTION
Most info is covered in the commit messages. However:

I added the multiple spy/spy-with variants for thread first and last as a convenience. Can remove those and leave just the one call for each if that is preferred, though it would mean anonymous functions when calling in the other context.

Also I noticed after I'd done the spy/spy-with variants commit that my change of the docstring for spy-with in the _previous_ commit had been wrong, but the original from before _that_ was also wrong. The original was a thread-first thread, but the spy-with function arg order meant it was thread-last. I made the thread thread-last in the doc, but of course functions like `update` don't run in a thread-last context... The latest commit fixes all of that and both docstrings contain a thread I've tested and proved works.